### PR TITLE
bugfix: Door Not Stopping Line of Sight

### DIFF
--- a/door.tscn
+++ b/door.tscn
@@ -36,6 +36,8 @@ sprite_frames = SubResource("SpriteFrames_t4u4y")
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 scale = Vector2(0.8, 0.8)
+collision_layer = 2
+collision_mask = 0
 
 [node name="CollisionShape2D2" type="CollisionShape2D" parent="StaticBody2D"]
 shape = SubResource("RectangleShape2D_hun61")


### PR DESCRIPTION
Configured the StaticBody2D node in door.tscn to use collision_layer 2 and collision_mask 0. That way, the raycast done for line of sight actually stops on closed doors since it checks against collision layer 2.